### PR TITLE
Fix Contact Your MP button hover style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -217,8 +217,8 @@
 }
 
 .cta-button-secondary {
-  background: transparent;
-  color: var(--host-navy);
+  background: var(--host-navy);
+  color: white;
   padding: 16px 32px;
   border-radius: 8px;
   font-weight: 600;
@@ -230,8 +230,8 @@
 }
 
 .cta-button-secondary:hover {
-  background: var(--host-navy);
-  color: white;
+  background: transparent;
+  color: var(--host-navy);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px rgba(30, 58, 138, 0.3);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,6 @@ import './App.css'
 // Import assets
 import hostLogoMain from './assets/host_logo_main.png'
 import hostLogoHorizontal from './assets/host_logo_horizontal.png'
-import hostLogoGrayscale from './assets/host_logo_grayscale.png'
 import hostLogoStacked from './assets/host_logo_stacked.png'
 
 // Navigation Component

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,13 +2,16 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 // https://vite.dev/config/
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- invert Contact Your MP button styling so it is navy by default and outline on hover
- remove unused grayscale logo import
- define `__dirname` in Vite config for lint compliance

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1d933e80483298f37b20de8d8c6c7