### PR TITLE
Add scroll-to-top on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,11 +27,11 @@ import {
   ArrowUp
 } from 'lucide-react'
 import './App.css'
+import ScrollToTop from './ScrollToTop'
 
 // Import assets
 import hostLogoMain from './assets/host_logo_main.png'
 import hostLogoHorizontal from './assets/host_logo_horizontal.png'
-import hostLogoGrayscale from './assets/host_logo_grayscale.png'
 import hostLogoStacked from './assets/host_logo_stacked.png'
 
 // Navigation Component
@@ -4455,7 +4455,7 @@ const Footer = () => {
 }
 
 // Scroll to Top Button
-const ScrollToTop = () => {
+const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
@@ -4496,6 +4496,7 @@ const ScrollToTop = () => {
 function App() {
   return (
     <Router>
+      <ScrollToTop />
       <div className="min-h-screen">
         <Navigation />
         <Routes>
@@ -4512,7 +4513,7 @@ function App() {
           <Route path="/legal" element={<LegalPage />} />
         </Routes>
         <Footer />
-        <ScrollToTop />
+        <ScrollToTopButton />
       </div>
     </Router>
   )

--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,12 @@
+/* eslint-env node */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 // https://vite.dev/config/
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   plugins: [react(),tailwindcss()],
   resolve: {


### PR DESCRIPTION
## Summary
- add ScrollToTop component to reset scroll position when navigating
- wire ScrollToTop into App and keep existing scroll button
- define __dirname in Vite config for linting

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1db1fb9f08329ac9175e3d8798bfc