### PR TITLE
fix: Tailwind v4 config for Netlify (PostCSS plugin + CSS import)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@tailwindcss/postcss": "^4.1.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: { '@tailwindcss/postcss': {} }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,18 +1,11 @@
 /* eslint-env node */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import tailwindcss from 'tailwindcss'
 import path from 'path'
 import { fileURLToPath } from 'url'
-
-// https://vitejs.dev/config/
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
+  plugins: [react()],
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
 })


### PR DESCRIPTION
## Summary
- remove Tailwind plugin from Vite config
- add PostCSS config using `@tailwindcss/postcss`
- depend on `@tailwindcss/postcss` for dev builds

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module '@tailwindcss/postcss' due to missing package)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8ec4a948329898a3c38968e2b78