### PR TITLE
chore: replace tailwind postcss plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@tailwindcss/postcss": "^4.0.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,1 +1,1 @@
-export default { plugins: { '@tailwindcss/postcss': {} } }
+export default { plugins: { tailwindcss: {} } }


### PR DESCRIPTION
## Summary
- use built-in `tailwindcss` postcss plugin
- drop `@tailwindcss/postcss` dev dependency

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b21bd677908329bd804d31e5fd1e0a